### PR TITLE
Clarify purpose of informal brief interview

### DIFF
--- a/docassemble/MAInformalAppelleeBrief/data/questions/informal_appellee_brief_form.yml
+++ b/docassemble/MAInformalAppelleeBrief/data/questions/informal_appellee_brief_form.yml
@@ -10,7 +10,7 @@ metadata:
   short title: >-
     Appellee informal brief
   description: |-
-    This interview will help you write an informal brief for filing with the Appeals Court. The Appeals Court permits only self-represented parties (no lawyer) to file an informal brief. Check the Appeals Court's website for [information about the informal brief program](https://www.mass.gov/info-details/appeals-court-informal-brief-pilot-program).   
+    This interview will help you write an informal brief if you are replying to an appellant brief filed in the Massachusetts Appeals Court. The Appeals Court permits only self-represented parties (no lawyer) to file an informal brief. Check the Appeals Court's website for [information about the informal brief program](https://www.mass.gov/info-details/appeals-court-informal-brief-pilot-program).   
   can_I_use_this_form: |
     If you are replying to an appellant brief, you can use this interview to write an informal brief to the Appeals Court. 
   before_you_start: |


### PR DESCRIPTION
Updated the description to clarify the purpose of the interview for replying to an appellant brief.